### PR TITLE
Update AverageAngCorResults.cpp

### DIFF
--- a/AverageAngCorResults.cpp
+++ b/AverageAngCorResults.cpp
@@ -104,7 +104,7 @@ int main(int argc, char *argv[])
                         if(ThetaAlphaLab<2.)AngularCorrelationHistogram->Fill(j,AngCorTable[i][j][k]*CrossSectionValue);
                         if(ThetaAlphaLab<2.)AngularCorrelationHistogramPerAngle[i]->Fill(j,AngCorTable[i][j][k]);
                         if(ThetaAlphaLab<2.)AngularCorrelationHistogramPerAnglePerAngle[i][k]->Fill(j,AngCorTable[i][j][k]);
-                        if(ThetaAlphaLab<2.)AngularCorrelationNormalisation->Fill(j);
+                        if(ThetaAlphaLab<2.)AngularCorrelationNormalisation->Fill(j*CrossSectionValue);
                         
                         PhiAlphaLab = (double)l;
                         Weight = AngCorTable[i][j][k]*CrossSectionValue;


### PR DESCRIPTION
Small fix suggestion to ensure that the AngularCorrelationNormalization histogram is weighted correctly, and hence the averaging is normalised to account for weighting on the Cross section.